### PR TITLE
Soft delete feature by using cache-control and expiry metadata for deciding on deletions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-LOCALSTACK_VERSION = 0.12.18
+LOCALSTACK_VERSION = 0.13.3
 
 .PHONY: test
 test:
@@ -24,11 +24,11 @@ cover:
 
 .PHONY: s3
 s3:
-	docker run -p 4572:4566 -e SERVICES=s3 localstack/localstack:$(LOCALSTACK_VERSION)
+	docker run --name s3 -p 4572:4566 -e SERVICES=s3 localstack/localstack:$(LOCALSTACK_VERSION)
 
 .PHONY: s3-bg
 s3-bg:
-	docker run -d -p 4572:4566 -e SERVICES=s3 localstack/localstack:$(LOCALSTACK_VERSION)
+	docker run -d --name s3 -p 4572:4566 -e SERVICES=s3 localstack/localstack:$(LOCALSTACK_VERSION)
 
 .PHONY: fixture
 fixture:

--- a/option.go
+++ b/option.go
@@ -13,11 +13,7 @@
 
 package s3sync
 
-import (
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-)
+import "github.com/aws/aws-sdk-go/service/s3/s3manager"
 
 const (
 	// Default number of parallel file sync jobs.
@@ -95,13 +91,6 @@ func WithContentTypeSelector(contentTypeSelector func(string) (string, error)) O
 func WithSoftDelete() Option {
 	return func(m *Manager) {
 		m.softDelete = true
-	}
-}
-
-// WithSoftDeleteHandler allows the caller to modify the softDelete behaviour
-func WithSoftDeleteHandler(softDeleteHandler func(s3iface.S3API, *s3.HeadObjectOutput, *fileInfo, *s3Path) error) Option {
-	return func(m *Manager) {
-		m.softDeleteHandler = softDeleteHandler
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -96,7 +96,7 @@ func WithSoftDelete() Option {
 
 // WithCacheControl sets the Cache-Control header for uploaded files as described in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 func WithCacheControl(value string) Option {
-    return func(m *Manager) {
-        m.cacheControl = &value
-    }
+	return func(m *Manager) {
+		m.cacheControl = &value
+	}
 }

--- a/option.go
+++ b/option.go
@@ -13,7 +13,11 @@
 
 package s3sync
 
-import "github.com/aws/aws-sdk-go/service/s3/s3manager"
+import (
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
 
 const (
 	// Default number of parallel file sync jobs.
@@ -91,6 +95,13 @@ func WithContentTypeSelector(contentTypeSelector func(string) (string, error)) O
 func WithSoftDelete() Option {
 	return func(m *Manager) {
 		m.softDelete = true
+	}
+}
+
+// WithSoftDeleteHandler allows the caller to modify the softDelete behaviour
+func WithSoftDeleteHandler(softDeleteHandler func(s3iface.S3API, *s3.HeadObjectOutput, *fileInfo, *s3Path) error) Option {
+	return func(m *Manager) {
+		m.softDeleteHandler = softDeleteHandler
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -86,3 +86,17 @@ func WithContentTypeSelector(contentTypeSelector func(string) (string, error)) O
 		m.contentTypeSelector = contentTypeSelector
 	}
 }
+
+// WithSoftDelete removes files with a delay
+func WithSoftDelete() Option {
+	return func(m *Manager) {
+		m.softDelete = true
+	}
+}
+
+// WithCacheControl sets the Cache-Control header for uploaded files as described in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+func WithCacheControl(value string) Option {
+    return func(m *Manager) {
+        m.cacheControl = &value
+    }
+}

--- a/s3sync.go
+++ b/s3sync.go
@@ -80,6 +80,12 @@ func New(sess *session.Session, options ...Option) *Manager {
 	for _, o := range options {
 		o(m)
 	}
+
+	if m.del && m.softDelete {
+		println("Both del and softDelete are enabled, preferring softDelete and disabling del")
+		m.del = false
+	}
+
 	return m
 }
 

--- a/s3sync.go
+++ b/s3sync.go
@@ -596,8 +596,7 @@ func filterFilesForSync(sourceFileChan, destFileChan chan *fileInfo, del bool, s
 					c <- &fileOp{fileInfo: destInfo, op: opDelete}
 				}
 			}
-		}
-		if softDelete {
+		} else if softDelete {
 			for _, destInfo := range destFiles {
 				if !destInfo.existsInSource {
 					// The source doesn't exist

--- a/s3sync.go
+++ b/s3sync.go
@@ -37,7 +37,6 @@ type Manager struct {
 	nJobs               int
 	del                 bool
 	softDelete          bool
-	softDeleteHandler   func(s3api s3iface.S3API, head *s3.HeadObjectOutput, file *fileInfo, destPath *s3Path) error
 	dryrun              bool
 	acl                 *string
 	guessMime           bool
@@ -85,12 +84,6 @@ func New(sess *session.Session, options ...Option) *Manager {
 	if m.del && m.softDelete {
 		println("Both del and softDelete are enabled, preferring softDelete and disabling del")
 		m.del = false
-	}
-
-	if m.softDeleteHandler == nil {
-		m.softDeleteHandler = func(s3api s3iface.S3API, head *s3.HeadObjectOutput, file *fileInfo, destPath *s3Path) error {
-			return softDeleteHandler(s3api, head, file, destPath)
-		}
 	}
 
 	return m
@@ -396,7 +389,7 @@ func (m *Manager) softDeleteRemote(file *fileInfo, destPath *s3Path) error {
 		return nil
 	}
 
-	err = m.softDeleteHandler(m.s3, head, file, &destFile)
+	err = softDeleteHandler(m.s3, head, file, &destFile)
 
 	return err
 }

--- a/util_test.go
+++ b/util_test.go
@@ -34,9 +34,11 @@ func getSession() *session.Session {
 }
 
 type s3Object struct {
-	path        string
-	size        int
-	contentType string
+	path         string
+	size         int
+	contentType  string
+	cacheControl string
+	expires      string
 }
 
 type s3ObjectList []s3Object
@@ -90,10 +92,22 @@ func listObjectsSorted(t *testing.T, bucket string) []s3Object {
 		if err != nil {
 			t.Fatal("GetObject failed", err)
 		}
+
+		cacheControl := ""
+		if o.CacheControl != nil {
+			cacheControl = *o.CacheControl
+		}
+		expires := ""
+		if o.Expires != nil {
+			expires = *o.Expires
+		}
+
 		objs = append(objs, s3Object{
-			path:        *obj.Key,
-			size:        int(*obj.Size),
-			contentType: *o.ContentType,
+			path:         *obj.Key,
+			size:         int(*obj.Size),
+			contentType:  *o.ContentType,
+			cacheControl: cacheControl,
+			expires:      expires,
 		})
 	}
 	sort.Sort(s3ObjectList(objs))


### PR DESCRIPTION
# What

A "soft delete" feature that first marks objects as expired, and on a later consecutive run it deletes objects that don't exist locally and have been expired remotely.

# Why

We'd like to not accumulate old assets and bundles to the S3 buckets for example Client CDN origin, but we also don't want to delete objects that are still potentially requested. After the objects expiry time has passed they should not be needed anywhere, so it should be safe to remove the file.

Example usage in `noice-cli`:

```
- type: s3_sync
  source: ./dist
  target: ${{ vars.PRD_CDN_BUCKET }}
  aws_access_key_id: ${{ vars.AWS_ACCESS_KEY_ID }}
  aws_secret_access_key: ${{ vars.AWS_SECRET_ACCESS_KEY }}
  assume_role: ${{ vars.PRD_CDN_ROLE }}
  aws_region: ${{ vars.AWS_REGION }}
  soft_delete: true
  cache_control: max-age=43200
```